### PR TITLE
ci: use dedicated Koso Labs Renovate app for renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,7 +11,7 @@ jobs:
     name: Renovate
     runs-on: macos-latest
     environment:
-      name: swift-lib-ssh-release
+      name: swift-lib-ssh-renovate
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -24,13 +24,13 @@ jobs:
       - id: app
         uses: actions/create-github-app-token@v3.2.0
         with:
-          client-id: Iv23liXdlxbyAb7jyk9P
-          private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          client-id: Iv23liXmycC1xcoZVDSz
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app.outputs.token }}
           RENOVATE_PLATFORM: github
           RENOVATE_ALLOWED_COMMANDS: '["^\\./build\\.sh$"]'
-          LOG_LEVEL: debug
+          LOG_LEVEL: info
         run: npx --yes renovate@44 ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Switches the `renovate.yml` workflow from the `Koso Labs Releaser` app (scoped for release-please) to a new dedicated `Koso Labs Renovate` app with Contents/Pull requests/Issues/Workflows write access.
- Reverts `LOG_LEVEL` from `debug` back to `info` (was temporarily bumped to diagnose the allowedCommands issue).

## Why
The hosted Renovate GitHub App was still installed on this repo (from before this migration) and was racing with the new self-hosted workflow to manage the same `renovate/*` branches. Self-hosted Renovate saw commits authored by an identity it didn't recognize as itself and defensively skipped the branch every time, so `postUpgradeTasks` (`./build.sh`) never ran. The hosted app has since been uninstalled from this repo; this PR also moves off the reused Releaser app in favor of a properly-scoped dedicated app (particularly `Workflows: write`, which Releaser lacks and which Renovate needs since it wants to bump `actions/setup-node` inside `renovate.yml` itself).

## Test plan
- [ ] Merge this PR
- [ ] Close stale PR #150 / delete branch `renovate/clibssh-native-dependencies` / close duplicate Dependency Dashboard issues (#3, #149)
- [ ] Manually trigger the Renovate workflow
- [ ] Confirm it creates a fresh PR authored by the new app, actually runs `build.sh`, and the resulting PR contains rebuilt `Sources/CLibSSH` artifacts